### PR TITLE
Timeouts for `fetch install` and expose more metadata from downloaded packages

### DIFF
--- a/lib/src/cache.dart
+++ b/lib/src/cache.dart
@@ -89,10 +89,11 @@ class Cache {
     }
     // Wrap the futureProcess in timeout, and return it when it's ready (or throw if timeout exceeded!)
     return futureProcess.then((Process p) =>
-      p.exitCode.timeout(Duration(seconds: timeout), onTimeout: () {
-        Process.killPid(p.pid);
-        throw Exception('Process with PID ${p.pid} took longer than ${timeout}s to complete. Killed.');
-      }).then((int exitCode) => p));
+        p.exitCode.timeout(Duration(seconds: timeout), onTimeout: () {
+          Process.killPid(p.pid);
+          throw Exception(
+              'Process with PID ${p.pid} took longer than ${timeout}s to complete. Killed.');
+        }).then((int exitCode) => p));
   }
 
   Future<Process> installDependencies(Package package, {int timeout}) async {
@@ -105,14 +106,16 @@ class Cache {
     }
 
     if (package.dependencies?.containsKey('flutter') == true) {
-      return raceProcess(Process.start('flutter', ['pub', 'get'],
-          workingDirectory: sourcePath), timeout);
+      return raceProcess(
+          Process.start('flutter', ['pub', 'get'],
+              workingDirectory: sourcePath),
+          timeout);
     }
 
     //TODO: recurse and run pub get in example dirs.
     print('Running "pub get" in ${path.basename(sourcePath)}');
-    return raceProcess(Process.start('pub', ['get'],
-        workingDirectory: sourcePath), timeout);
+    return raceProcess(
+        Process.start('pub', ['get'], workingDirectory: sourcePath), timeout);
   }
 
   Future<bool> _download(Package package) async {

--- a/lib/src/commands/cache.dart
+++ b/lib/src/commands/cache.dart
@@ -6,38 +6,6 @@ import '../common.dart';
 
 // todo (pq): change this to cache, with list as a sub command and add clean
 
-class CacheCommand extends BaseCommand {
-  CacheCommand() {
-    addSubcommand(ListSubCommand());
-    addSubcommand(CacheStatsCommand());
-    addSubcommand(CacheCleanSubCommand());
-  }
-
-  @override
-  String get description => 'cache commands.';
-
-  @override
-  String get name => 'cache';
-
-//  @override
-//  Future run() {
-//    print(cache.size());
-//    return Future.value();
-//  }
-}
-
-class ListSubCommand extends BaseCommand {
-  ListSubCommand() {
-    addSubcommand(CacheSizeCommand());
-  }
-
-  @override
-  String get description => 'package cache commands';
-
-  @override
-  String get name => 'cache';
-}
-
 class CacheCleanSubCommand extends BaseCommand {
   @override
   String get description => 'clean cache (remove stale packages)';
@@ -60,6 +28,26 @@ class CacheCleanSubCommand extends BaseCommand {
 
     return Future.value();
   }
+}
+
+class CacheCommand extends BaseCommand {
+  CacheCommand() {
+    addSubcommand(ListSubCommand());
+    addSubcommand(CacheStatsCommand());
+    addSubcommand(CacheCleanSubCommand());
+  }
+
+  @override
+  String get description => 'cache commands.';
+
+  @override
+  String get name => 'cache';
+
+//  @override
+//  Future run() {
+//    print(cache.size());
+//    return Future.value();
+//  }
 }
 
 class CacheSizeCommand extends BaseCommand {
@@ -129,4 +117,16 @@ class CacheStatsCommand extends BaseCommand {
 
     return Future.value();
   }
+}
+
+class ListSubCommand extends BaseCommand {
+  ListSubCommand() {
+    addSubcommand(CacheSizeCommand());
+  }
+
+  @override
+  String get description => 'package cache commands';
+
+  @override
+  String get name => 'cache';
 }

--- a/lib/src/commands/fetch.dart
+++ b/lib/src/commands/fetch.dart
@@ -18,10 +18,19 @@ class FetchCommand extends BaseCommand {
 
   FetchCommand() {
     argParser.addOption('criteria', abbr: 'c', valueHelp: 'crit_1,..,crit_n');
-    argParser.addOption('max', abbr: 'm', valueHelp: 'packages', help: 'number of packages to download.', defaultsTo: defaultFetchLimit.toString());
-    argParser.addOption('timeout', valueHelp: 'seconds', help: 'time allotted for the download of each package.', defaultsTo: "disabled");
-    argParser.addFlag('install', help: 'install dependencies.', defaultsTo: true);
-    argParser.addFlag('verbose', help: 'show verbose output.', negatable: false);
+    argParser.addOption('max',
+        abbr: 'm',
+        valueHelp: 'packages',
+        help: 'number of packages to download.',
+        defaultsTo: defaultFetchLimit.toString());
+    argParser.addOption('timeout',
+        valueHelp: 'seconds',
+        help: 'time allotted for the download of each package.',
+        defaultsTo: 'disabled');
+    argParser.addFlag('install',
+        help: 'install dependencies.', defaultsTo: true);
+    argParser.addFlag('verbose',
+        help: 'show verbose output.', negatable: false);
   }
 
   bool get install => argResults['install'];
@@ -130,7 +139,7 @@ class FetchCommand extends BaseCommand {
       print('(Max processed package count of $maxCount reached.)');
     }
 
-    print("---");
+    print('---');
 
     return packages;
   }

--- a/lib/src/commands/fetch.dart
+++ b/lib/src/commands/fetch.dart
@@ -10,12 +10,6 @@ import '../package.dart';
 class FetchCommand extends BaseCommand {
   static const defaultFetchLimit = 10;
 
-  @override
-  String get description => 'fetch packages.';
-
-  @override
-  String get name => 'fetch';
-
   FetchCommand() {
     argParser.addOption('criteria', abbr: 'c', valueHelp: 'crit_1,..,crit_n');
     argParser.addOption('max',
@@ -33,7 +27,13 @@ class FetchCommand extends BaseCommand {
         help: 'show verbose output.', negatable: false);
   }
 
+  @override
+  String get description => 'fetch packages.';
+
   bool get install => argResults['install'];
+
+  @override
+  String get name => 'fetch';
 
   @override
   Future run() async {

--- a/lib/src/commands/fetch.dart
+++ b/lib/src/commands/fetch.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' as io;
 
 import '../../hooks/criteria/fetch.dart';
 import '../cache.dart';
@@ -16,23 +17,26 @@ class FetchCommand extends BaseCommand {
   String get name => 'fetch';
 
   FetchCommand() {
-    argParser.addOption('max', abbr: 'm', valueHelp: 'packages');
     argParser.addOption('criteria', abbr: 'c', valueHelp: 'crit_1,..,crit_n');
-    argParser.addFlag('no-install', help: 'do not install dependencies.');
-    argParser.addFlag('verbose', help: 'show verbose output.');
+    argParser.addOption('max', abbr: 'm', valueHelp: 'packages', help: 'number of packages to download.', defaultsTo: defaultFetchLimit.toString());
+    argParser.addOption('timeout', valueHelp: 'seconds', help: 'time allotted for the download of each package.', defaultsTo: "disabled");
+    argParser.addFlag('install', help: 'install dependencies.', defaultsTo: true);
+    argParser.addFlag('verbose', help: 'show verbose output.', negatable: false);
   }
 
-  bool get install => !argResults['no-install'];
+  bool get install => argResults['install'];
 
   @override
   Future run() async {
     final maxFetch = toInt(argResults['max'] ?? defaultFetchLimit);
+    final timeout = toInt(argResults['timeout'] ?? -1);
+
     final criteria =
         Criteria.fromArgs(argResults['criteria']) ?? defaultFetchCriteria;
 
     int skipCount = 0;
     var packages = await _listPackages(criteria, maxFetch, onSkip: (p, c) {
-      print('Skipped package:${p.name} (${c.onFail(p)})');
+      print('Skipped package: ${p.name} (${c.onFail(p)})');
       ++skipCount;
     });
 
@@ -43,11 +47,17 @@ class FetchCommand extends BaseCommand {
       }
 
       if (install && !cache.hasDependenciesInstalled(package)) {
-        print('Installing dependencies...');
-        var result = await cache.installDependencies(package);
-        if (result != null) {
-          print(result.stdout);
-          print(result.stderr);
+        print('Installing dependencies for ${package.name}');
+        try {
+          if (verbose) {
+            await cache.installDependencies(package, timeout: timeout)
+              ..stdout.listen(io.stdout.add)
+              ..stderr.listen(io.stderr.add);
+          } else {
+            await cache.installDependencies(package, timeout: timeout);
+          }
+        } catch (e) {
+          print(e);
         }
       }
     };
@@ -111,7 +121,6 @@ class FetchCommand extends BaseCommand {
           break;
         }
       }
-      print(count);
       packagePage = packageBody['next_url'];
     }
     print('$count packages processed');
@@ -121,7 +130,7 @@ class FetchCommand extends BaseCommand {
       print('(Max processed package count of $maxCount reached.)');
     }
 
-    print(count);
+    print("---");
 
     return packages;
   }

--- a/lib/src/filters.dart
+++ b/lib/src/filters.dart
@@ -2,5 +2,5 @@ import 'package:pub_semver/pub_semver.dart';
 
 final _dart2 = VersionConstraint.parse('>=2.0.0');
 
-bool isDart2(String sdkVersion) =>
-    VersionConstraint.parse(sdkVersion).allowsAny(_dart2);
+bool isDart2([String sdkVersion]) =>
+    VersionConstraint.parse(sdkVersion ?? 'any').allowsAny(_dart2);

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -7,6 +7,9 @@ import 'common.dart';
 
 abstract class Package {
   double get overallScore;
+  double get popularityScore;
+  double get maintenanceScore;
+  double get healthScore;
 
   /// Cache-relative path to local package source.
   String get sourcePath => '$name-$version';
@@ -39,6 +42,9 @@ abstract class Package {
     package.name = name;
     package.version = packageData['version'];
     package.overallScore = packageData['score'];
+    package.popularityScore = packageData['popularity'];
+    package.maintenanceScore = packageData['maintenance'];
+    package.healthScore = packageData['health'];
     package.dir = Directory('third_party/cache/${packageData['sourcePath']}');
     return package;
   }
@@ -47,6 +53,9 @@ abstract class Package {
     jsonData[name] = {
       'version': version,
       'score': overallScore,
+      'popularity': popularityScore,
+      'maintenance': maintenanceScore,
+      'health': healthScore,
       'sourcePath': sourcePath,
     };
   }
@@ -115,6 +124,12 @@ class LocalPackage extends Package {
 
   @override
   double overallScore;
+  @override
+  double popularityScore;
+  @override
+  double maintenanceScore;
+  @override
+  double healthScore;
 
   @override
   String toString() => '$name-$version';
@@ -160,7 +175,16 @@ class RemotePackage extends Package {
   String get repository => pubspec['repository'];
 
   @override
-  double get overallScore => metrics.overallScore;
+  double get overallScore => metrics.overall;
+
+  @override
+  double get popularityScore => metrics.popularity;
+
+  @override
+  double get maintenanceScore => metrics.maintenance;
+
+  @override
+  double get healthScore => metrics.health;
 
   @override
   String get sdkConstraint {
@@ -174,8 +198,10 @@ class Metrics {
 
   Metrics(this._data);
 
-  double get overallScore {
-    var scorecard = _data['scorecard'];
-    return scorecard != null ? scorecard['overallScore'] : null;
-  }
+  double _getScorecardMetric(String name) => _data['scorecard'] != null ? _data['scorecard'][name] : null;
+
+  double get overall => _getScorecardMetric('overallScore');
+  double get popularity => _getScorecardMetric('popularityScore');
+  double get maintenance => _getScorecardMetric('maintenanceScore');
+  double get health => _getScorecardMetric('healthScore');
 }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -198,7 +198,8 @@ class Metrics {
 
   Metrics(this._data);
 
-  double _getScorecardMetric(String name) => _data['scorecard'] != null ? _data['scorecard'][name] : null;
+  double _getScorecardMetric(String name) =>
+      _data['scorecard'] != null ? _data['scorecard'][name] : null;
 
   double get overall => _getScorecardMetric('overallScore');
   double get popularity => _getScorecardMetric('popularityScore');

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -5,64 +5,6 @@ import 'package:yaml/yaml.dart' as yaml;
 
 import 'common.dart';
 
-abstract class Package {
-  double get overallScore;
-  double get popularityScore;
-  double get maintenanceScore;
-  double get healthScore;
-
-  /// Cache-relative path to local package source.
-  String get sourcePath => '$name-$version';
-
-  String get name;
-
-  String get archiveUrl;
-
-  String get version;
-
-  String get sdkConstraint;
-
-  Directory get dir => null;
-
-  Map<String, dynamic> get dependencies => pubspec['dependencies'];
-
-  Map<String, dynamic> get pubspec;
-
-  String get repository;
-
-  Package();
-
-  factory Package.fromData(String name, dynamic jsonData) {
-    final packageData = jsonData[name];
-    if (packageData == null) {
-      return null;
-    }
-
-    final package = LocalPackage();
-    package.name = name;
-    package.version = packageData['version'];
-    package.overallScore = packageData['score'];
-    package.popularityScore = packageData['popularity'];
-    package.maintenanceScore = packageData['maintenance'];
-    package.healthScore = packageData['health'];
-    package.dir = Directory('third_party/cache/${packageData['sourcePath']}');
-    return package;
-  }
-
-  void addToJsonData(dynamic jsonData) {
-    jsonData[name] = {
-      'version': version,
-      'score': overallScore,
-      'popularity': popularityScore,
-      'maintenance': maintenanceScore,
-      'health': healthScore,
-      'sourcePath': sourcePath,
-    };
-  }
-
-  bool isFlutterPackage() => dependencies?.containsKey('flutter') == true;
-}
-
 class LocalPackage extends Package {
   @override
   String archiveUrl;
@@ -76,6 +18,25 @@ class LocalPackage extends Package {
   @override
   String name;
 
+  @override
+  String repository;
+
+  @override
+  String version;
+
+  @override
+  String sdkConstraint;
+
+  @override
+  double overallScore;
+
+  @override
+  double popularityScore;
+
+  @override
+  double maintenanceScore;
+  @override
+  double healthScore;
   @override
   Map<String, dynamic> get dependencies {
     if (_pubspec == null) {
@@ -114,25 +75,79 @@ class LocalPackage extends Package {
   }
 
   @override
-  String repository;
-
-  @override
-  String version;
-
-  @override
-  String sdkConstraint;
-
-  @override
-  double overallScore;
-  @override
-  double popularityScore;
-  @override
-  double maintenanceScore;
-  @override
-  double healthScore;
-
-  @override
   String toString() => '$name-$version';
+}
+
+class Metrics {
+  final _data;
+
+  Metrics(this._data);
+
+  double get health => _getScorecardMetric('healthScore');
+
+  double get maintenance => _getScorecardMetric('maintenanceScore');
+  double get overall => _getScorecardMetric('overallScore');
+  double get popularity => _getScorecardMetric('popularityScore');
+  double _getScorecardMetric(String name) =>
+      _data['scorecard'] != null ? _data['scorecard'][name] : null;
+}
+
+abstract class Package {
+  Package();
+  factory Package.fromData(String name, dynamic jsonData) {
+    final packageData = jsonData[name];
+    if (packageData == null) {
+      return null;
+    }
+
+    final package = LocalPackage();
+    package.name = name;
+    package.version = packageData['version'];
+    package.overallScore = packageData['score'];
+    package.popularityScore = packageData['popularity'];
+    package.maintenanceScore = packageData['maintenance'];
+    package.healthScore = packageData['health'];
+    package.dir = Directory('third_party/cache/${packageData['sourcePath']}');
+    return package;
+  }
+  String get archiveUrl;
+  Map<String, dynamic> get dependencies => pubspec['dependencies'];
+
+  Directory get dir => null;
+
+  double get healthScore;
+
+  double get maintenanceScore;
+
+  String get name;
+
+  double get overallScore;
+
+  double get popularityScore;
+
+  Map<String, dynamic> get pubspec;
+
+  String get repository;
+
+  String get sdkConstraint;
+
+  /// Cache-relative path to local package source.
+  String get sourcePath => '$name-$version';
+
+  String get version;
+
+  void addToJsonData(dynamic jsonData) {
+    jsonData[name] = {
+      'version': version,
+      'score': overallScore,
+      'popularity': popularityScore,
+      'maintenance': maintenanceScore,
+      'health': healthScore,
+      'sourcePath': sourcePath,
+    };
+  }
+
+  bool isFlutterPackage() => dependencies?.containsKey('flutter') == true;
 }
 
 class RemotePackage extends Package {
@@ -141,6 +156,39 @@ class RemotePackage extends Package {
   Metrics metrics;
 
   RemotePackage._(this._data);
+
+  @override
+  String get archiveUrl => _data['latest']['archive_url'];
+
+  @override
+  double get healthScore => metrics.health;
+
+  @override
+  double get maintenanceScore => metrics.maintenance;
+
+  @override
+  String get name => _data['name'];
+
+  @override
+  double get overallScore => metrics.overall;
+
+  @override
+  double get popularityScore => metrics.popularity;
+
+  @override
+  Map<String, dynamic> get pubspec => _data['latest']['pubspec'];
+
+  @override
+  String get repository => pubspec['repository'];
+
+  @override
+  String get sdkConstraint {
+    final env = pubspec['environment'];
+    return env == null ? null : env['sdk'];
+  }
+
+  @override
+  String get version => _data['latest']['version'];
 
   static Future<Package> init(Map<String, dynamic> data) async {
     final package = RemotePackage._(data);
@@ -158,51 +206,4 @@ class RemotePackage extends Package {
     }
     return package;
   }
-
-  @override
-  String get name => _data['name'];
-
-  @override
-  String get archiveUrl => _data['latest']['archive_url'];
-
-  @override
-  String get version => _data['latest']['version'];
-
-  @override
-  Map<String, dynamic> get pubspec => _data['latest']['pubspec'];
-
-  @override
-  String get repository => pubspec['repository'];
-
-  @override
-  double get overallScore => metrics.overall;
-
-  @override
-  double get popularityScore => metrics.popularity;
-
-  @override
-  double get maintenanceScore => metrics.maintenance;
-
-  @override
-  double get healthScore => metrics.health;
-
-  @override
-  String get sdkConstraint {
-    final env = pubspec['environment'];
-    return env == null ? null : env['sdk'];
-  }
-}
-
-class Metrics {
-  final _data;
-
-  Metrics(this._data);
-
-  double _getScorecardMetric(String name) =>
-      _data['scorecard'] != null ? _data['scorecard'][name] : null;
-
-  double get overall => _getScorecardMetric('overallScore');
-  double get popularity => _getScorecardMetric('popularityScore');
-  double get maintenance => _getScorecardMetric('maintenanceScore');
-  double get health => _getScorecardMetric('healthScore');
 }


### PR DESCRIPTION
* Expose popularity/maintenance/health scores for the downloaded packages.
  * Write the values to index.json so they can be used from other tools
* Add a `--timeout` option to 'fetch' command (disabled by default)
* Minor improvements to 'fetch':
  * Reduce output when not 'verbose'
  * Tweak argument parsing
    * Prevent -[no-]no-install flag
    * Other minor things

Use the new timeout like this:

```
dart pub_crawl.dart fetch --criteria flutter --max 5 --timeout 300
```

Now, if the pub get operation takes longer than 300 seconds, it'll be aborted and the script should continue downloading other packages.
