### PR TITLE
Fix documentation, make pub_crawl.dart executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ customize behavior in provided "hook" classes.
 
 Supported commands are:
 
-* `pub fetch` - fetch packages that match given criteria (for example, `fetch --max 5 --criteria flutter,min_score:.75`
+* `fetch` - fetch packages that match given criteria (for example, `fetch --max 5 --criteria flutter,min_score:.75`
    fetches Flutter packages whose pub score is 75 or higher)
-* `pub analyze` - analyze packages
-* `pub lint` - a variation of `analyze` that makes it easy to lint packages with specified rules
+* `analyze` - analyze packages
+* `lint` - a variation of `analyze` that makes it easy to lint packages with specified rules
    (for example, `lint --rules=await_only_futures,avoid_as`)
-* `pub clean` - deletes cached packages
+* `clean` - deletes cached packages
 
 For example,
 

--- a/bin/pub_crawl.dart
+++ b/bin/pub_crawl.dart
@@ -1,3 +1,5 @@
+#!/usr/bin/env dart
+
 //  Copyright 2019 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
1. The documentation listed commands as `pub fetch`, `pub analyze`,
   etc.  This is wrong since these are not subcommands on `pub`.

2. Make pub_crawl.dart executable so that it can be run directly on
   POSIX systems.