### PR TITLE
Add a depends_on:PACKAGE criterion

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -83,21 +83,37 @@ class Criteria {
   }
 
   factory Criteria.forName(String name) {
+    String value;
+    if (name.contains(':')) {
+      final nameValue = name.split(':');
+      name = nameValue[0];
+      value = nameValue[1];
+    }
+
     switch (name) {
       case 'flutter':
+        return Criteria.forName('depends_on:flutter');
+      case 'depends_on':
+        if (value == null) {
+          throw Exception('Argument required for "$name"');
+        }
         return Criteria(
-          matches: (p) => p.dependencies?.containsKey('flutter') == true,
-          onFail: (_) => 'does not use flutter',
+          matches: (p) => p.dependencies?.containsKey(value) == true,
+          onFail: (_) => 'does not use $value',
+        );
+      case 'min_score':
+        if (value == null) {
+          throw Exception('Argument required for "$name"');
+        }
+
+        final score = toDouble(value);
+        return Criteria(
+          matches: (p) => p.overallScore >= score,
+          onFail: (p) => 'score too low: ${p.overallScore}',
         );
     }
-    if (name.startsWith('min_score:')) {
-      final score = toDouble(name.split(':')[1]);
-      return Criteria(
-        matches: (p) => p.overallScore >= score,
-        onFail: (p) => 'score too low: ${p.overallScore}',
-      );
-    }
-    return null;
+
+    throw Exception('Unrecognized criteria name: $name');
   }
 }
 


### PR DESCRIPTION
pub_crawl seems like a useful tool to get a rough idea about the
amount of fallout from a breaking change to a package.  It therefore
would be useful to allow it to find dependent packages for packages
other than flutter.

Generalize the `flutter` criterion to a new `depends_on:PACKAGE`
criterion, and make the `flutter` one to leverage it.

(Note that this is very slow since it iterates over all packages in
pub.dev.  A better long-term approach probably would be to submit a
`dependency:PACKAGE` query to pub.dev and to process the results.)

Additionally make pub_crawl fail if given unrecognized criteria.
(This isn't as friendly as it should be, but it's better than
proceeding on an unwanted and expensive operation.)