### PR TITLE
Update fetch to use api which returns all packages, add `no-` negation support to criteria

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -83,6 +83,10 @@ class Criteria {
   }
 
   factory Criteria.forName(String name) {
+    if (name.startsWith('no-')) {
+      return Criteria.negated(Criteria.forName(name.substring(3)));
+    }
+
     String value;
     if (name.contains(':')) {
       final nameValue = name.split(':');
@@ -115,6 +119,10 @@ class Criteria {
 
     throw Exception('Unrecognized criteria name: $name');
   }
+
+  factory Criteria.negated(Criteria other) => Criteria(
+      matches: (p) => !other.matches(p),
+      onFail: (p) => '${other.onFail(p)} (negated)');
 }
 
 /// A simple visitor for analysis options files.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   cli_util: ^0.1.3
   linter: ^0.1.82
+  pool: ^1.4.0
 
 dev_dependencies:
   pedantic: ^1.0.0


### PR DESCRIPTION
* Pass the `?compact=1` query param when listing packages which returns all package names in one request
  * Then fetch package data individually, up to 10 at a time
* Also adds general negation support to Criteria via the `no-` prefix.

cc @jonasfj